### PR TITLE
Chuwi Hi13 ACCEL_MOUNT_MATRIX update

### DIFF
--- a/hwdb/60-sensor.hwdb
+++ b/hwdb/60-sensor.hwdb
@@ -67,6 +67,10 @@ sensor:modalias:acpi:SMO8500*:dmi:*svn*ASUSTeK*:*pn*TP300LJ*
 sensor:modalias:acpi:BOSC0200*:dmi:*:svnHampoo:pnD2D3_Vi8A1:*
  ACCEL_MOUNT_MATRIX=0, -1, 0; -1, 0, 0; 0, 0, 1
 
+# Chuwi Hi13
+sensor:modalias:acpi:KIOX000A*:dmi:svnChuwi*:pnHi13
+ ACCEL_MOUNT_MATRIX=1, 0, 0; 0, -1, 0; 0, 0, 1
+
 #########################################
 # Cube
 #########################################

--- a/hwdb/60-sensor.hwdb
+++ b/hwdb/60-sensor.hwdb
@@ -68,7 +68,7 @@ sensor:modalias:acpi:BOSC0200*:dmi:*:svnHampoo:pnD2D3_Vi8A1:*
  ACCEL_MOUNT_MATRIX=0, -1, 0; -1, 0, 0; 0, 0, 1
 
 # Chuwi Hi13
-sensor:modalias:acpi:KIOX000A*:dmi:svnChuwi*:pnHi13
+sensor:modalias:acpi:KIOX000A*:dmi:*:svnChuwi*:pnHi13:*
  ACCEL_MOUNT_MATRIX=1, 0, 0; 0, -1, 0; 0, 0, 1
 
 #########################################


### PR DESCRIPTION
Following latest kernel update, I had to update the dmi trigger to be able to properly detected

udevadm info -export-db (extract)

P: /devices/pci0000:00/0000:00:17.0/i2c_designware.4/i2c-9/i2c-KIOX000A:00/iio:device0
N: iio:device0
E: ACCEL_MOUNT_MATRIX=1, 0, 0; 0, -1, 0; 0, 0, 1
E: DEVNAME=/dev/iio:device0
E: DEVPATH=/devices/pci0000:00/0000:00:17.0/i2c_designware.4/i2c-9/i2c-KIOX000A:00/iio:device0
E: DEVTYPE=iio_device
E: IIO_SENSOR_PROXY_TYPE=iio-buffer-accel
E: MAJOR=242
E: MINOR=0
E: SUBSYSTEM=iio
E: SYSTEMD_WANTS=iio-sensor-proxy.service
E: TAGS=:systemd:
E: USEC_INITIALIZED=7994668

